### PR TITLE
launch: remove gcrypt LD_PRELOAD which is not necessary

### DIFF
--- a/launch
+++ b/launch
@@ -41,9 +41,6 @@ if [ -e /dev/nvidiactl ]; then
   fi
 fi
 
-# Use libgcrypt provided by the Steam docker image (needed by HL1 engine games)
-export LD_PRELOAD="/lib/i386-linux-gnu/libgcrypt.so.11:/lib/x86_64-linux-gnu/libgcrypt.so.11"
-
 #
 # Try to load host's libGL (generic or Nvidia 32/64-bit) drivers
 #


### PR DESCRIPTION
I investigated a bit #10, there are at least 3 issues:

1. warnings about libgcrypt `wrong ELF class`
2. warnings about pulseaudio `wrong ELF class`
3. warnings about d-bus `ln: /lib/x86_64-linux-gnu/libdbus-1.so.3: no version information available (required by /h8_64/pulseaudio/libpulsecommon-9.0.so`

I am not yet sure how to solve 2. and 3., but at least 1. is easy enough: you simply don't need to set `LD_PRELOAD`, because it is located in the standard/expected location. I tested with CS:CZ (huh!), it works fine. Any idea why you set it?